### PR TITLE
Fix Vite env config to use root .env file

### DIFF
--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,8 +1,13 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  // Load env file from root directory
+  const env = loadEnv(mode, path.resolve(__dirname, '../../'), '');
+  
+  return {
   plugins: [react()],
   server: {
     host: '0.0.0.0',
@@ -52,5 +57,11 @@ export default defineConfig({
       'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
       'Access-Control-Allow-Headers': '*'
     }
+  },
+  define: {
+    'process.env.VITE_API_URL': JSON.stringify(env.VITE_API_URL || 'http://localhost:12001'),
+    'process.env.VITE_SUPABASE_URL': JSON.stringify(env.SUPABASE_URL),
+    'process.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(env.SUPABASE_ANON_KEY)
   }
+  };
 });


### PR DESCRIPTION
Consolidates environment configuration by:
- Removing separate .env.local file in UI package
- Configuring Vite to load env vars from root .env file
- Mapping root env vars to VITE_ prefixed variables for frontend use

@garyfairy41 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/dda0691f91ac41d3b8718f24350b9bed)